### PR TITLE
define proc quietly before using it

### DIFF
--- a/script/compile.do
+++ b/script/compile.do
@@ -8,15 +8,6 @@
 #
 #====================================================================================
 
-#
-# Define library name, UVVM Util path and BFM path.
-#
-quietly set library_name uvvm_util
-quietly set util_path src_util
-quietly set bfm_path src_bfm
-
-
-
 #-------------------------------------------------------
 # Setup
 #
@@ -36,6 +27,13 @@ proc quietly { args } {
     uplevel $args; list;
   }
 }
+
+#
+# Define library name, UVVM Util path and BFM path.
+#
+quietly set library_name uvvm_util
+quietly set util_path src_util
+quietly set bfm_path src_bfm
 
 #
 # Detect simulator


### PR DESCRIPTION
Riviera-PRO doesn't have the `quietly` function, so it needs to be defined before using it.

Fixes #4